### PR TITLE
Using list comprehension

### DIFF
--- a/PyHyLight/test.py
+++ b/PyHyLight/test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 '''
 
 Run this code to test the PyHyLight library, the NRF-Arduino
@@ -15,21 +16,16 @@ ard.open()
 notes = ['C','Db','D','Eb','E','F','Gb','G','Ab','A','Bb','B']
 off = np.zeros(10) # Array of zeros to turn off HyLights
 
+hylighter_ix = range(0,8)
+serial_wait = .05 #wait time between each send in sec
+
 # Cycle through Mary's colors, all the same color
 for note in notes:
-	send(0,hylrgb(maryrgb[note]),power=10)
-	send(1,hylrgb(maryrgb[note]),power=10)
-	send(2,hylrgb(maryrgb[note]),power=10)
-	send(3,hylrgb(maryrgb[note]),power=10)
-	send(4,hylrgb(maryrgb[note]),power=10)
-	send(5,hylrgb(maryrgb[note]),power=10)
-	time.sleep(1.5)
-	send(0,off)
-	send(1,off)
-	send(2,off)
-	send(3,off)
-	send(4,off)
-	send(5,off)
+    [(time.sleep(serial_wait),send(ix,hylrgb(maryrgb[note]),power=10)) for ix in hylighter_ix]
+    
+    time.sleep(1.5)
+    
+    [(time.sleep(serial_wait), send(ix, off)) for ix in hylighter_ix]
 
 # Cycle through Mary's colors, alternating
 i,j,k,l,m,n = 0,1,2,3,4,5
@@ -55,12 +51,8 @@ for note in notes*2:
 		n=0
 	time.sleep(1)
 
-send(0,off)
-send(1,off)
-send(2,off)
-send(3,off)
-send(4,off)
-send(5,off)
+
+[(time.sleep(serial_wait), send(ix, off)) for ix in hylighter_ix]
 
 # Cycle through Mary's colors faster
 for note in notes*3:
@@ -85,9 +77,4 @@ for note in notes*3:
 		n=0
 	time.sleep(.3)
 
-send(0,off)
-send(1,off)
-send(2,off)
-send(3,off)
-send(4,off)
-send(5,off)
+[(time.sleep(serial_wait), send(ix, off)) for ix in hylighter_ix]


### PR DESCRIPTION
I added list comprehension for the send functions. This allows us to use a list of hylighter indices for the series of send functions. To add or remove addressable receivers, just edit hylighter_ix. The list comprehension also includes a time.sleep function, whose interval is adjusted with serial_wait.
Also, added utf-8 encoding for portability. 